### PR TITLE
include: Fix use of <disk_access.h> -> <disk/disk_access.h>

### DIFF
--- a/zfs_diskio.c
+++ b/zfs_diskio.c
@@ -27,7 +27,7 @@
 
 #include <diskio.h>	/* FatFs lower layer API */
 #include <ffconf.h>
-#include <disk_access.h>
+#include <disk/disk_access.h>
 
 static const char* const pdrv_str[] = {_VOLUME_STRS};
 


### PR DESCRIPTION
Fix #include <disk_access.h> as it has been deprecated and
should be #include <disk/disk_access.h>.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>