### PR TITLE
fs: Add kconfig option for enabling exFAT support

### DIFF
--- a/include/ffconf.h
+++ b/include/ffconf.h
@@ -227,8 +227,11 @@
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the file system object (FATFS) is used for the file data transfer. */
 
-
-#define _FS_EXFAT	0
+#if defined(CONFIG_FS_FATFS_EXFAT)
+#define _FS_EXFAT	CONFIG_FS_FATFS_EXFAT
+#else
+#define _FS_EXFAT   0
+#endif
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */


### PR DESCRIPTION
Add Kconfig options for exposing the support of exFAT

Expose the configuration for enable/disable the exFAT support to Kconfig.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>