### PR TITLE
fat_fs: Add support for the "win" variable alignment in FATFS struct

### DIFF
--- a/include/ff.h
+++ b/include/ff.h
@@ -173,7 +173,7 @@ typedef struct {
 	LBA_t	bitbase;		/* Allocation bitmap base sector */
 #endif
 	LBA_t	winsect;		/* Current sector appearing in the win[] */
-	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
+	BYTE    win[FF_MAX_SS] __attribute__((aligned(FS_FATFS_WINDOW_ALIGNMENT)));	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
 } FATFS;
 
 

--- a/include/ffconf.h
+++ b/include/ffconf.h
@@ -253,6 +253,16 @@
 /  disk_ioctl() function. */
 
 
+#if defined(CONFIG_FS_FATFS_WINDOW_ALIGNMENT)
+#define FS_FATFS_WINDOW_ALIGNMENT	CONFIG_FS_FATFS_WINDOW_ALIGNMENT
+#else
+#define FS_FATFS_WINDOW_ALIGNMENT	1
+#endif /* defined(CONFIG_FS_FATFS_WINDOW_ALIGNMENT) */
+/* This option is to align FATFS->win variable to meet the mmc controller requirement,
+ * such as designware mmc controller. Aligning the WINDOW variable with 512 will
+ * drastically increase the size of the FATFS structure*/
+
+
 
 /*---------------------------------------------------------------------------/
 / System Configurations


### PR DESCRIPTION
This is to support Sypnosys Designware SDMMC controller read and write
operation where the buffer address is needed to be 16bytes and 512bytes
aligned. Adding macro FS_FATFS_WIN_ALIGN to align the "win" variable
address in FATFS struct.

Signed-off-by: Boon Khai Ng <boon.khai.ng@intel.com>