### PR TITLE
fs: Remove typo if using older standard than C99

### DIFF
--- a/include/ff.h
+++ b/include/ff.h
@@ -55,7 +55,6 @@ typedef WORD			WCHAR;	/* UTF-16 character type */
 
 #else  	/* Earlier than C99 */
 #define FF_INTDEF 1
-jhello wor
 typedef unsigned int	UINT;	/* int must be 16-bit or 32-bit */
 typedef unsigned char	BYTE;	/* char must be 8-bit */
 typedef unsigned short	WORD;	/* 16-bit unsigned integer */


### PR DESCRIPTION
"jhello wor" isn't a valid c statement.
This was clearly added by accident, and I'm guessing never found
because it's always been compiled with C99 or later.

I can't figure out how to actually test this because if I tell west to
build samples/subsys/fs/fat_fs with C90 a bunch of other stuff fails.

Signed-off-by: Mark Furland <mark@fur.land>
