### PR TITLE
zephyr: fix ffconf.h override use of STRINGIZE

### DIFF
--- a/include/ffconf.h
+++ b/include/ffconf.h
@@ -291,11 +291,11 @@
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
 #ifdef ZEPHYR_CONFIG_OVERRIDE
-#define STRINGIZE_AGAIN(x) #x
-#define STRINGIZE(x) STRINGIZE_AGAIN(x)
-#include STRINGIZE(ZEPHYR_CONFIG_OVERRIDE)
-#undef STRINGIZE
-#undef STRINGIZE_AGAIN
+#define FFCONF_STRINGIZE_AGAIN(x) #x
+#define FFCONF_STRINGIZE(x) FFCONF_STRINGIZE_AGAIN(x)
+#include FFCONF_STRINGIZE(ZEPHYR_CONFIG_OVERRIDE)
+#undef FFCONF_STRINGIZE
+#undef FFCONF_STRINGIZE_AGAIN
 #endif
 /* End of Zephyr specific configuration override */
 


### PR DESCRIPTION
This is a "standard" macro name that we shouldn't be overriding. Namespace this with an FFCONF_ prefix to avoid clashes with other modules, such as the one currently observed in this twister error:

```
In file included from /__w/zephyr/modules/fs/fatfs/include/ff.h:29,
                 from /__w/zephyr/zephyr/subsys/fs/fat_fs.c:16:
/__w/zephyr/modules/fs/fatfs/include/ffconf.h:295: error: "STRINGIZE" redefined [-Werror]
  295 | #define STRINGIZE(x) STRINGIZE_AGAIN(x)
      |
In file included from /__w/zephyr/modules/hal/silabs/gecko/emlib/inc/em_common.h:34,
                 from /__w/zephyr/modules/hal/silabs/gecko/emlib/inc/em_core.h:34,
                 from /__w/zephyr/modules/hal/silabs/gecko/emlib/inc/em_bus.h:34,
                 from ../../../../../../../soc/arm/silabs_exx32/efm32gg11b/soc.h:25,
                 from ../../../../../../../include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h:19,
                 from ../../../../../../../include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h:11,
                 from ../../../../../../../include/zephyr/arch/arm/aarch32/mpu/arm_mpu.h:14,
                 from ../../../../../../../include/zephyr/arch/arm/aarch32/arch.h:266,
                 from ../../../../../../../include/zephyr/arch/cpu.h:19,
                 from ../../../../../../../include/zephyr/kernel_includes.h:33,
                 from ../../../../../../../include/zephyr/kernel.h:17,
                 from /__w/zephyr/zephyr/subsys/fs/fat_fs.c:9:
/__w/zephyr/modules/hal/silabs/gecko/common/inc/sl_common.h:82: note: this is the location of the previous definition
   82 | #define STRINGIZE(X) #X
      |
cc1: all warnings being treated as errors
```

