### PR TITLE
fix: add module name

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: fatfs
 build:
   cmake-ext: True
   kconfig-ext: True


### PR DESCRIPTION
This MR adds the module name in zephyr/module.yml, as is stated in the [official documentation](https://docs.zephyrproject.org/latest/develop/modules.html#module-name):

> Each Zephyr module is given a name by which it can be referred to in the build system.
> The name should be specified in the zephyr/module.yml file. This will ensure the module name is not changeable through user-defined directory names or west manifest files.
